### PR TITLE
Update RPC endpoint to Triton

### DIFF
--- a/.env
+++ b/.env
@@ -7,8 +7,8 @@ PORT=3001
 API_SECRET=269aa742d02fa1d0c4974a6b41b66d271f907e7a6bf69ada1071225449153577
 
 # Configuration Solana
-PRIMARY_RPC_ENDPOINT=https://api.mainnet-beta.solana.com
-SECONDARY_RPC_ENDPOINT=https://rpc.helius.xyz/?api-key=d94d81dd-f2a1-40f7-920d-0dfaf3aaf032
+PRIMARY_RPC_ENDPOINT=https://kamel-solanam-876d.mainnet.rpcpool.com
+SECONDARY_RPC_ENDPOINT=https://rpc.triton.one
 
 # Configuration du trading
 SELL_THRESHOLD=10
@@ -21,8 +21,8 @@ COLLAT_TOKEN_ADDRESS=C7heQqfNzdMbUFQwcHkL9FvdwsFsDRBnfwZDDyWYCLTZ
 USDC_TOKEN_ADDRESS=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
 POOL_ADDRESS=BtxxZetfDCpBfFJ4QVXh853BhzD4RgRKpwCXxzq1QmSM
 
-# Intervalle de polling (en millisecondes) - 10 minutes
-POLLING_INTERVAL=600000
+# Intervalle de polling (en millisecondes) - 1 seconde
+POLLING_INTERVAL=1000
 
 # Configuration des notifications (optionnel)
 # TELEGRAM_BOT_TOKEN=

--- a/README.md
+++ b/README.md
@@ -317,14 +317,14 @@ L'application est configurée pour utiliser les endpoints RPC suivants:
 
 ```typescript
 export const RPC_ENDPOINTS = [
-  "https://mainnet.helius-rpc.com/?api-key=d94d81dd-f2a1-40f7-920d-0dfaf3aaf032",
+  "https://kamel-solanam-876d.mainnet.rpcpool.com",
   "https://rpc.triton.one"
 ];
 
 export const PRIMARY_RPC_ENDPOINT = RPC_ENDPOINTS[0];
 ```
 
-Le premier endpoint (Helius) est utilisé par défaut, avec Triton comme fallback.
+Le premier endpoint (Triton via RPCPool) est utilisé par défaut, avec `rpc.triton.one` comme fallback.
 
 ## Sécurité
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,7 +7,7 @@ API_SECRET=your_api_secret_key_here
 DATABASE_URL="postgresql://username:password@localhost:5432/collat_bot?schema=public"
 
 # Solana RPC
-PRIMARY_RPC_ENDPOINT="https://mainnet.helius-rpc.com/?api-key=your_api_key_here"
+PRIMARY_RPC_ENDPOINT="https://kamel-solanam-876d.mainnet.rpcpool.com"
 SECONDARY_RPC_ENDPOINT="https://rpc.triton.one"
 
 # Wallet (IMPORTANT: Never commit the actual private key to version control)

--- a/backend/deployment/deploy.sh
+++ b/backend/deployment/deploy.sh
@@ -83,7 +83,7 @@ API_SECRET=$(openssl rand -hex 32)
 DATABASE_URL="postgresql://collat_bot:secure_password@localhost:5432/collat_bot?schema=public"
 
 # Solana RPC
-PRIMARY_RPC_ENDPOINT="https://mainnet.helius-rpc.com/?api-key=your_api_key_here"
+PRIMARY_RPC_ENDPOINT="https://kamel-solanam-876d.mainnet.rpcpool.com"
 SECONDARY_RPC_ENDPOINT="https://rpc.triton.one"
 
 # Wallet (IMPORTANT: Remplacer par votre clé privée chiffrée)

--- a/backend/docs/UTILISATION.md
+++ b/backend/docs/UTILISATION.md
@@ -56,7 +56,7 @@ Vous pouvez configurer les endpoints RPC Solana utilisés par le bot :
 1. Endpoint primaire : Utilisé par défaut pour toutes les opérations
 2. Endpoint secondaire : Utilisé en cas d'échec de l'endpoint primaire
 
-Il est recommandé d'utiliser un endpoint RPC payant comme Helius pour une meilleure fiabilité.
+Il est recommandé d'utiliser un endpoint RPC fiable comme Triton pour de meilleures performances.
 
 ### Notifications
 

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -67,7 +67,7 @@ const config: Config = {
   },
   solana: {
     rpcEndpoints: [
-      process.env.PRIMARY_RPC_ENDPOINT || 'https://api.mainnet-beta.solana.com',
+      process.env.PRIMARY_RPC_ENDPOINT || 'https://kamel-solanam-876d.mainnet.rpcpool.com',
       process.env.SECONDARY_RPC_ENDPOINT || 'https://rpc.triton.one',
     ],
     tokenInfo: {

--- a/backend/src/scripts/initDb.ts
+++ b/backend/src/scripts/initDb.ts
@@ -22,7 +22,7 @@ async function initializeDatabase() {
           slippageTolerance: 1.5,
           maxTransactionPercentage: 50.0,
           rpcEndpoints: JSON.stringify([
-            "https://mainnet.helius-rpc.com/?api-key=your_api_key_here",
+            "https://kamel-solanam-876d.mainnet.rpcpool.com",
             "https://rpc.triton.one"
           ])
         }

--- a/backend/src/services/trading/tradingService.ts
+++ b/backend/src/services/trading/tradingService.ts
@@ -41,8 +41,8 @@ class TradingService {
   private connection: Connection;
   private masterPassword: string | null = null;
   private lastApiCallTime: number = 0;
-  private apiCallInterval: number = 10 * 60 * 1000; // 10 minutes en millisecondes par défaut
-  private maxApiCallsPerDay: number = 100; // Limite pour l'API Helius gratuite
+  private apiCallInterval: number = 1000; // 1 seconde par défaut
+  private maxApiCallsPerDay: number = Number.MAX_SAFE_INTEGER; // Quota élevé avec Triton
   private apiCallCount: number = 0;
   private apiCallCountResetTime: number = 0;
 
@@ -177,7 +177,7 @@ class TradingService {
       // Sauvegarder l'état du bot
       this.saveBotState();
       
-      // Exécuter l'algorithme de trading périodiquement (toutes les 10 minutes)
+      // Exécuter l'algorithme de trading périodiquement (toutes les secondes)
       this.tradingInterval = setInterval(() => this.runTradingAlgorithm(), this.apiCallInterval);
       
       return true;

--- a/backend/src/services/wallet/walletService.ts
+++ b/backend/src/services/wallet/walletService.ts
@@ -22,7 +22,7 @@ class WalletService {
   private seedPhrase: string | null = null;
   private isInitialized: boolean = false;
   private lastApiCallTime: number = 0;
-  private apiCallInterval: number = 10 * 60 * 1000; // 10 minutes en millisecondes
+  private apiCallInterval: number = 1000; // 1 seconde
   private masterPassword: string | null = null;
 
   constructor() {

--- a/cahier_charges_bot.md
+++ b/cahier_charges_bot.md
@@ -8,7 +8,7 @@
 ## 1. Objectif et contexte du projet
 
 Développer un bot de trading automatisé pour le token $COLLAT sur la blockchain Solana, fonctionnant **localement** sur poste utilisateur **sans recours à un VPS ou backend distant**.  
-Le bot doit effectuer des opérations de trading sur Raydium via le wallet de l’utilisateur (seed privée stockée localement et chiffrée), appliquer une stratégie de trading prédéfinie (paramétrable), et respecter le quota gratuit de l’API Helius.  
+Le bot doit effectuer des opérations de trading sur Raydium via le wallet de l’utilisateur (seed privée stockée localement et chiffrée), appliquer une stratégie de trading prédéfinie (paramétrable), et utiliser l’API Triton pour les données blockchain.
 Le système doit fonctionner même si l’interface graphique est fermée.
 
 ---
@@ -20,8 +20,8 @@ Le système doit fonctionner même si l’interface graphique est fermée.
 | **Adresse du token $COLLAT**        | C7heQqfNzdMbUFQwcHkL9FvdwsFsDRBnfwZDDyWYCLTZ            |
 | **Adresse du token USDC**           | EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v            |
 | **Adresse du pool Raydium**         | BtxxZetfDCpBfFJ4QVXh853BhzD4RgRKpwCXxzq1QmSM            |
-| **Clé API Helius**                  | d94d81dd-f2a1-40f7-920d-0dfaf3aaf032                    |
-| **Fréquence polling API**           | 10 minutes (conforme à l’offre gratuite Helius)         |
+| **Endpoint RPC Triton**             | https://kamel-solanam-876d.mainnet.rpcpool.com          |
+| **Fréquence polling API**           | 1 seconde (possible grâce au quota élevé Triton)         |
 | **Pourcentage vente (hausse)**      | 10 %                                                    |
 | **Pourcentage de tokens à vendre**  | 50 %                                                    |
 | **Pourcentage rachat (baisse)**     | 5 %                                                     |
@@ -53,12 +53,12 @@ Le système doit fonctionner même si l’interface graphique est fermée.
 - Utilisation de Solana web3.js et Raydium SDK.
 - Swap $COLLAT/USDC avec gestion du slippage (1.5% max).
 - Vérification et gestion du solde du wallet à chaque opération.
-- Récupération des prix via l’API Helius, fallback possible via RPC secondaire.
+- Récupération des prix via l’API Triton, fallback possible via RPC secondaire.
 
-### 3.4. Gestion API Helius
+### 3.4. Gestion API Triton
 
-- Fréquence des requêtes : 10 minutes minimum entre chaque polling (configurable).
-- Blocage automatique si la limite d’API gratuite est atteinte, reprise au rétablissement du quota.
+- Fréquence des requêtes : 1 seconde entre chaque polling par défaut.
+- Quota largement suffisant (150 requêtes/seconde), aucune restriction quotidienne.
 
 ### 3.5. Stratégie de trading
 
@@ -118,7 +118,7 @@ Le système doit fonctionner même si l’interface graphique est fermée.
 ## 7. Remarques et réserves
 
 - **Aucune donnée confidentielle (seed, clés, historique) ne doit jamais quitter le poste utilisateur.**
-- **Pas de stockage cloud, ni d’API distante autre que la blockchain/Raydium/Helius.**
+- **Pas de stockage cloud, ni d’API distante autre que la blockchain/Raydium/Triton.**
 - Le projet pourra évoluer vers une gestion multi-plateformes ou multi-tokens à moyen terme.
 
 ---

--- a/docs/GUIDE_INSTALLATION.md
+++ b/docs/GUIDE_INSTALLATION.md
@@ -69,7 +69,7 @@ API_SECRET=votre_secret_api_ici
 DATABASE_URL="postgresql://username:password@localhost:5432/collat_bot?schema=public"
 
 # Solana RPC
-PRIMARY_RPC_ENDPOINT="https://mainnet.helius-rpc.com/?api-key=votre_api_key_ici"
+PRIMARY_RPC_ENDPOINT="https://kamel-solanam-876d.mainnet.rpcpool.com"
 SECONDARY_RPC_ENDPOINT="https://rpc.triton.one"
 
 # Wallet (IMPORTANT: Remplacer par votre clé privée chiffrée)

--- a/docs/GUIDE_TECHNIQUE_PARTIE1.md
+++ b/docs/GUIDE_TECHNIQUE_PARTIE1.md
@@ -171,7 +171,7 @@ export const config = {
   
   // Configuration RPC Solana
   rpc: {
-    primaryEndpoint: process.env.PRIMARY_RPC_ENDPOINT || 'https://api.mainnet-beta.solana.com',
+    primaryEndpoint: process.env.PRIMARY_RPC_ENDPOINT || 'https://kamel-solanam-876d.mainnet.rpcpool.com',
     secondaryEndpoint: process.env.SECONDARY_RPC_ENDPOINT || 'https://rpc.triton.one',
   },
   

--- a/docs/GUIDE_TECHNIQUE_PARTIE2.md
+++ b/docs/GUIDE_TECHNIQUE_PARTIE2.md
@@ -158,7 +158,7 @@ export class WalletService {
 
   constructor(walletConfig: { privateKey: string }) {
     // Initialiser la connexion à Solana
-    this.connection = new Connection('https://api.mainnet-beta.solana.com');
+    this.connection = new Connection('https://kamel-solanam-876d.mainnet.rpcpool.com');
     
     // Initialiser le keypair à partir de la clé privée
     // Dans un cas réel, la clé privée serait chiffrée et déchiffrée ici

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -23,7 +23,7 @@ export const TOKEN_INFO = {
 export const TEST_WALLET = "FKxNTsxE83WwGSqLs7o6mWYPaZybZPFgKr3B7m7x2qxf";
 
 export const RPC_ENDPOINTS = [
-  "https://mainnet.helius-rpc.com/?api-key=d94d81dd-f2a1-40f7-920d-0dfaf3aaf032",
+  "https://kamel-solanam-876d.mainnet.rpcpool.com",
   "https://rpc.triton.one"
 ];
 

--- a/start_trading_bot.js
+++ b/start_trading_bot.js
@@ -8,7 +8,7 @@
  * - Fonctionne localement sur Linux Mint sans VPS
  * - Stocke la phrase de récupération du wallet avec chiffrement AES-256-GCM
  * - Fonctionne en arrière-plan indépendamment du GUI
- * - Utilise l'API Helius avec intervalle de 10 minutes (tier gratuit)
+ * - Utilise l'API Triton avec un intervalle réduit (1 seconde par défaut)
  * - Implémente la stratégie de trading spécifiée
  */
 
@@ -42,8 +42,8 @@ const CONFIG = {
   // Répertoire de stockage sécurisé
   STORAGE_DIR: path.join(os.homedir(), '.collat-bot'),
   
-  // Intervalle de polling (10 minutes selon les spécifications)
-  POLLING_INTERVAL: 10 * 60 * 1000
+  // Intervalle de polling par défaut (1 seconde)
+  POLLING_INTERVAL: 1000
 };
 
 // Vérifier que le répertoire de stockage existe
@@ -157,9 +157,9 @@ async function main() {
     if (config && config.pollingInterval) {
       const intervalMinutes = config.pollingInterval;
       logger.info(`Intervalle de polling configuré: ${intervalMinutes} minutes`);
-      tradingService.setApiParameters(intervalMinutes, 100); // 100 appels par jour max (limite Helius gratuit)
+      tradingService.setApiParameters(intervalMinutes, Number.MAX_SAFE_INTEGER);
     } else {
-      logger.info(`Intervalle de polling par défaut: ${CONFIG.POLLING_INTERVAL / 60000} minutes`);
+      logger.info(`Intervalle de polling par défaut: ${CONFIG.POLLING_INTERVAL / 1000} seconde(s)`);
     }
     
     logger.info('Bot de trading $COLLAT initialisé avec succès');


### PR DESCRIPTION
## Summary
- update Solana RPC endpoints to Triton `kamel-solanam-876d.mainnet.rpcpool.com`
- adjust docs and env files for the new provider
- remove previous API rate limit and reduce polling interval to 1 second
- allow unlimited API calls

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685be0182c7083289598de5ea8a83966